### PR TITLE
Refactor database functions

### DIFF
--- a/server/firestore-methods.ts
+++ b/server/firestore-methods.ts
@@ -24,7 +24,7 @@ export async function getAllShowings(database: Firestore, setIsLoading: SetIsLoa
     }
     catch (err) {
         setIsLoading(false)
-        return { error: "Error retrieving showings" }
+        return []
 
     }
 }

--- a/server/firestore-methods.ts
+++ b/server/firestore-methods.ts
@@ -29,7 +29,7 @@ export async function getAllShowings(database: Firestore, setIsLoading: SetIsLoa
     }
 }
 
-export async function getShowingDetails(database: Firestore, showingId: string | undefined) {
+export async function getSingleShowing(database: Firestore, showingId: string | undefined) {
     if (showingId === undefined) {
         return { error: "No showing ID given" }
     }

--- a/server/firestore-methods.ts
+++ b/server/firestore-methods.ts
@@ -3,21 +3,26 @@ import { getDoc } from "firebase/firestore";
 import { Showing } from "../types";
 
 export async function getAllShowings(database: Firestore){
-    const showingsCollection = collection(database, "showings")  
-    const showingsQuery = query(showingsCollection)
-    const snapshot = await getDocs(showingsQuery)
-
-    const fetchedShowings: Showing[] = []
-    snapshot.forEach((document: any)=>{
-        const showing = {
-            id: document.id,
-            ...document.data()
-        }
-
-        fetchedShowings.push(showing)
-    })
-
-    return fetchedShowings
+    try {
+        const showingsCollection = collection(database, "showings")  
+        const showingsQuery = query(showingsCollection)
+        const snapshot = await getDocs(showingsQuery)
+    
+        const fetchedShowings: Showing[] = []
+        snapshot.forEach((document: any)=>{
+            const showing = {
+                id: document.id,
+                ...document.data()
+            }
+    
+            fetchedShowings.push(showing)
+        })
+    
+        return fetchedShowings
+    }
+    catch (err) {
+        return { error: "Error retrieving showings" }
+    }
 }
 
 export async function getShowingDetails(database: Firestore, showingId: string | undefined) {

--- a/server/firestore-methods.ts
+++ b/server/firestore-methods.ts
@@ -1,5 +1,24 @@
-import { doc, Firestore } from "@firebase/firestore";
+import { collection, doc, Firestore, getDocs, query } from "@firebase/firestore";
 import { getDoc } from "firebase/firestore";
+import { Showing } from "../types";
+
+export async function getAllShowings(database: Firestore){
+    const showingsCollection = collection(database, "showings")  
+    const showingsQuery = query(showingsCollection)
+    const snapshot = await getDocs(showingsQuery)
+
+    const fetchedShowings: Showing[] = []
+    snapshot.forEach((document: any)=>{
+        const showing = {
+            id: document.id,
+            ...document.data()
+        }
+
+        fetchedShowings.push(showing)
+    })
+
+    return fetchedShowings
+}
 
 export async function getShowingDetails(database: Firestore, showingId: string | undefined) {
     if (showingId === undefined) {

--- a/server/firestore-methods.ts
+++ b/server/firestore-methods.ts
@@ -2,7 +2,9 @@ import { collection, doc, Firestore, getDocs, query } from "@firebase/firestore"
 import { getDoc } from "firebase/firestore";
 import { Showing } from "../types";
 
-export async function getAllShowings(database: Firestore){
+type SetIsLoading = React.Dispatch<React.SetStateAction<boolean>>
+
+export async function getAllShowings(database: Firestore, setIsLoading: SetIsLoading) {
     try {
         const showingsCollection = collection(database, "showings")  
         const showingsQuery = query(showingsCollection)
@@ -17,11 +19,13 @@ export async function getAllShowings(database: Firestore){
     
             fetchedShowings.push(showing)
         })
-    
+        setIsLoading(false)
         return fetchedShowings
     }
     catch (err) {
+        setIsLoading(false)
         return { error: "Error retrieving showings" }
+
     }
 }
 

--- a/server/omdb-methods.ts
+++ b/server/omdb-methods.ts
@@ -6,7 +6,7 @@ export async function getFilmDetails(omdbKey: string, filmName: string) {
             `https://www.omdbapi.com/?apikey=${omdbKey}&t=${filmName}`
         );
     
-        if (!response.Response) {
+        if (response.data.Response === "False") {
             return { error: "Film details could not be retrieved" }
         }
 

--- a/src/Showings/Showings.tsx
+++ b/src/Showings/Showings.tsx
@@ -6,24 +6,25 @@ import { getAllShowings } from "../../server/firestore-methods";
 
 function Showings() {
     const [showings, setShowings] = useState<Showing[]>([])
+    const [isLoading, setIsLoading] = useState(true)
     const firestore = useContext(FirebaseContext)
 
     useEffect(()=>{
         (async()=>{
-            const fetchedShowings = await getAllShowings(firestore)
+            const fetchedShowings = await getAllShowings(firestore, setIsLoading)
             setShowings(fetchedShowings)
         })()
     }, [])
     
-    return showings.length ? (
-    <>
-        <h1>Upcoming Showings</h1>
-        {showings.map((showing)=> <ShowingCard showing={showing} key={showing.id}/>)}
-    </>
+    return isLoading ? (
+        <>
+            <h1>Loading showings...</h1>
+        </>
     ) : (
-    <>
-        <h1>Loading showings...</h1>
-    </>
+        <>
+            <h1>Upcoming Showings</h1>
+            {showings.map((showing)=> <ShowingCard showing={showing} key={showing.id}/>)}
+        </>
     )
 }
 

--- a/src/Showings/Showings.tsx
+++ b/src/Showings/Showings.tsx
@@ -5,27 +5,36 @@ import { Showing } from "../../types";
 import { getAllShowings } from "../../server/firestore-methods";
 
 function Showings() {
-    const [showings, setShowings] = useState<Showing[]>([])
-    const [isLoading, setIsLoading] = useState(true)
-    const firestore = useContext(FirebaseContext)
+    const [showings, setShowings] = useState<Showing[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const firestore = useContext(FirebaseContext);
 
-    useEffect(()=>{
-        (async()=>{
-            const fetchedShowings = await getAllShowings(firestore, setIsLoading)
-            setShowings(fetchedShowings)
-        })()
-    }, [])
-    
+    useEffect(() => {
+        (async () => {
+            const fetchedShowings = await getAllShowings(
+                firestore,
+                setIsLoading
+            );
+            setShowings(fetchedShowings);
+        })();
+    }, []);
+
     return isLoading ? (
         <>
             <h1>Loading showings...</h1>
         </>
+    ) : showings.length === 0 ? (
+        <>
+            <h1>Something went wrong whilst retrieving showings</h1>
+        </>
     ) : (
         <>
             <h1>Upcoming Showings</h1>
-            {showings.map((showing)=> <ShowingCard showing={showing} key={showing.id}/>)}
+            {showings.map((showing) => (
+                <ShowingCard showing={showing} key={showing.id} />
+            ))}
         </>
-    )
+    );
 }
 
-export default Showings
+export default Showings;

--- a/src/Showings/Showings.tsx
+++ b/src/Showings/Showings.tsx
@@ -1,32 +1,18 @@
-import { collection, getDocs, query } from "@firebase/firestore";
 import { useContext, useEffect, useState } from "react";
 import ShowingCard from "./ShowingCard";
 import FirebaseContext from "../../hooks/FirebaseContext";
 import { Showing } from "../../types";
+import { getAllShowings } from "../../server/firestore-methods";
 
 function Showings() {
     const [showings, setShowings] = useState<Showing[]>([])
-    const database = useContext(FirebaseContext)
-
-    async function getDocuments(){
-        const showingsCollection = collection(database, "showings")  
-        const showingsQuery = query(showingsCollection)
-        const snapshot = await getDocs(showingsQuery)
-
-        const fetchedShowings: Showing[] = []
-        snapshot.forEach((document: any)=>{
-            const showing = {
-                id: document.id,
-                ...document.data()
-            }
-
-            fetchedShowings.push(showing)
-        })
-        setShowings(fetchedShowings)
-    }
+    const firestore = useContext(FirebaseContext)
 
     useEffect(()=>{
-        getDocuments()
+        (async()=>{
+            const fetchedShowings = await getAllShowings(firestore)
+            setShowings(fetchedShowings)
+        })()
     }, [])
     
     return showings.length ? (

--- a/src/SingleShowing/SingleShowing.tsx
+++ b/src/SingleShowing/SingleShowing.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import FirebaseContext from "../../hooks/FirebaseContext";
 import { getDate, getTime } from "../../utils/datetime-utils";
-import { getShowingDetails } from "../../server/firestore-methods";
+import { getSingleShowing } from "../../server/firestore-methods";
 import { getFilmDetails } from "../../server/omdb-methods";
 import "./SingleShowing.css";
 
@@ -16,7 +16,7 @@ function SingleShowing() {
 
     useEffect(() => {
         (async () => {
-            const showingDetails = await getShowingDetails(
+            const showingDetails = await getSingleShowing(
                 firestore,
                 showingId
             );

--- a/src/SingleShowing/SingleShowing.tsx
+++ b/src/SingleShowing/SingleShowing.tsx
@@ -11,7 +11,7 @@ const omdbKey = import.meta.env.VITE_OMBD_KEY;
 function SingleShowing() {
     const showingId = useParams().showing_id;
     const [showing, setShowing] = useState<any>(null);
-    const [movieDetails, setMovieDetails] = useState<any>(null);
+    const [filmDetails, setFilmDetails] = useState<any>(null);
     const firestore = useContext(FirebaseContext);
 
     useEffect(() => {
@@ -28,17 +28,17 @@ function SingleShowing() {
         (async () => {
             if (showing) {
                 const filmDetails = await getFilmDetails(omdbKey, showing.film);
-                setMovieDetails(filmDetails);
+                setFilmDetails(filmDetails);
             }
         })();
     }, [showing]);
 
-    return !showing || !movieDetails ? (
+    return !showing || !filmDetails ? (
         <h1>Loading...</h1>
     ) : showing.error ? (
         <h1>{showing.error}</h1>
-    ) : movieDetails.error ? (
-        <h1>{movieDetails.error}</h1>
+    ) : filmDetails.error ? (
+        <h1>{filmDetails.error}</h1>
     ) : (
         <>
             <h1>{showing.name}</h1>
@@ -48,15 +48,15 @@ function SingleShowing() {
             <p>{showing.description}</p>
             <h2>Movie Details</h2>
             <p>
-                {showing.film} ({movieDetails.year})
+                {showing.film} ({filmDetails.year})
             </p>
-            <p>Rated: {movieDetails.rating}</p>
-            <p>Runtime: {movieDetails.runtime}</p>
-            <p>Directed by: {movieDetails.director}</p>
-            <p>Genre(s): {movieDetails.genre}</p>
-            <p>Plot: {movieDetails.plot}</p>
+            <p>Rated: {filmDetails.rating}</p>
+            <p>Runtime: {filmDetails.runtime}</p>
+            <p>Directed by: {filmDetails.director}</p>
+            <p>Genre(s): {filmDetails.genre}</p>
+            <p>Plot: {filmDetails.plot}</p>
             <a
-                href={`https://www.imdb.com/title/${movieDetails.imdbId}`}
+                href={`https://www.imdb.com/title/${filmDetails.imdbId}`}
                 target="_blank"
             >
                 Read more about the film on IMDb

--- a/src/SingleShowing/SingleShowing.tsx
+++ b/src/SingleShowing/SingleShowing.tsx
@@ -2,9 +2,9 @@ import { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import FirebaseContext from "../../hooks/FirebaseContext";
 import { getDate, getTime } from "../../utils/datetime-utils";
-import { getShowingDetails } from "../../server/firestore-methods"
-import { getFilmDetails } from "../../server/omdb-methods"
-import "./SingleShowing.css"
+import { getShowingDetails } from "../../server/firestore-methods";
+import { getFilmDetails } from "../../server/omdb-methods";
+import "./SingleShowing.css";
 
 const omdbKey = import.meta.env.VITE_OMBD_KEY;
 
@@ -15,53 +15,54 @@ function SingleShowing() {
     const firestore = useContext(FirebaseContext);
 
     useEffect(() => {
-        (async ()=>{
-            const showingDetails = await getShowingDetails(firestore, showingId);
-            setShowing(showingDetails)
-        })()
+        (async () => {
+            const showingDetails = await getShowingDetails(
+                firestore,
+                showingId
+            );
+            setShowing(showingDetails);
+        })();
     }, []);
 
-    useEffect(()=>{
-        (async()=>{
+    useEffect(() => {
+        (async () => {
             if (showing) {
-                const filmDetails = await getFilmDetails(omdbKey, showing.film)
-                setMovieDetails(filmDetails)
+                const filmDetails = await getFilmDetails(omdbKey, showing.film);
+                setMovieDetails(filmDetails);
             }
-        })()
-    }, [showing])
+        })();
+    }, [showing]);
 
     return !showing || !movieDetails ? (
         <h1>Loading...</h1>
+    ) : showing.error ? (
+        <h1>{showing.error}</h1>
+    ) : movieDetails.error ? (
+        <h1>{movieDetails.error}</h1>
     ) : (
-        showing.error ? (
-            <h1>{showing.error}</h1>
-    ) : (
-        movieDetails.error ? (
-            <h1>{movieDetails.error}</h1>
-        ) : (
-            <>
-                <h1>{showing.name}</h1>
-                <p>{getDate(showing.datetime)}</p>
-                <p>{getTime(showing.datetime)}</p>
-                <img src={`${showing.poster}`} alt={`Poster for ${showing.film}`} />
-                <p>{showing.description}</p>
-                <h2>Movie Details</h2>
-                <p>
-                    {showing.film} ({movieDetails.year})
-                </p>
-                <p>Rated: {movieDetails.rating}</p>
-                <p>Runtime: {movieDetails.runtime}</p>
-                <p>Directed by: {movieDetails.director}</p>
-                <p>Genre(s): {movieDetails.genre}</p>
-                <p>Plot: {movieDetails.plot}</p>
-                <a
-                    href={`https://www.imdb.com/title/${movieDetails.imdbId}`}
-                    target="_blank"
-                >
-                    Read more about the film on IMDb
-                </a>
-            </>
-    )))
+        <>
+            <h1>{showing.name}</h1>
+            <p>{getDate(showing.datetime)}</p>
+            <p>{getTime(showing.datetime)}</p>
+            <img src={`${showing.poster}`} alt={`Poster for ${showing.film}`} />
+            <p>{showing.description}</p>
+            <h2>Movie Details</h2>
+            <p>
+                {showing.film} ({movieDetails.year})
+            </p>
+            <p>Rated: {movieDetails.rating}</p>
+            <p>Runtime: {movieDetails.runtime}</p>
+            <p>Directed by: {movieDetails.director}</p>
+            <p>Genre(s): {movieDetails.genre}</p>
+            <p>Plot: {movieDetails.plot}</p>
+            <a
+                href={`https://www.imdb.com/title/${movieDetails.imdbId}`}
+                target="_blank"
+            >
+                Read more about the film on IMDb
+            </a>
+        </>
+    );
 }
 
 export default SingleShowing;


### PR DESCRIPTION
Renames getDocuments to getAllShowings

Renames getShowingDetails to getSingleShowing

Moves getAllShowings and getSingleShowing into firestore-methods.ts file

Adds try/catch blocks to both getAllShowings and getSingleShowing

Adds error message to Showings when no showings are retrieved

Updates getFilmDetails condition in if statement to send error message correctly when omdb API is unable to provide film details in response

Updates name of movieDetails state to filmDetails