### PR TITLE
Http secure

### DIFF
--- a/server/omdb-methods.ts
+++ b/server/omdb-methods.ts
@@ -32,7 +32,7 @@ export async function getFilmDetails(omdbKey: string, imdbId: string): Promise<F
 
 export async function getFilmPreview(omdbKey: string, searchInput: string, isNameSearch: boolean): Promise<FilmPreviewResponse>{
     try {
-        const response = await axios.get(`http://www.omdbapi.com/?apikey=${omdbKey}&${isNameSearch ? "t" : "i"}=${searchInput}`)
+        const response = await axios.get(`https://www.omdbapi.com/?apikey=${omdbKey}&${isNameSearch ? "t" : "i"}=${searchInput}`)
 
         if (response.data.Response === "False") {
             return { error: "No film found, please try again" }

--- a/src/PaymentComplete/PaymentResponse.tsx
+++ b/src/PaymentComplete/PaymentResponse.tsx
@@ -13,7 +13,7 @@ const successIcon = (
         height="14"
         viewBox="0 0 16 14"
         fill="none"
-        xmlns="http://www.w3.org/2000/svg"
+        xmlns="https://www.w3.org/2000/svg"
     >
         <path
             fillRule="evenodd"
@@ -30,7 +30,7 @@ const errorIcon = (
         height="16"
         viewBox="0 0 16 16"
         fill="none"
-        xmlns="http://www.w3.org/2000/svg"
+        xmlns="https://www.w3.org/2000/svg"
     >
         <path
             fillRule="evenodd"
@@ -47,7 +47,7 @@ const infoIcon = (
         height="14"
         viewBox="0 0 14 14"
         fill="none"
-        xmlns="http://www.w3.org/2000/svg"
+        xmlns="https://www.w3.org/2000/svg"
     >
         <path
             fillRule="evenodd"


### PR DESCRIPTION
Updates URLs used in getFilmPreview and PaymentResponse to be https instead of http